### PR TITLE
Revert "Update README.md"

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,5 @@ Flax - https://flaxengine.com/
 Castle Engine - https://castle-engine.io/  
 GameBoy Studio - https://www.gbstudio.dev/  
 Bitty Engine - https://paladin-t.github.io/bitty/  
-Beef Editor and Language - https://www.beeflang.org
 
 


### PR DESCRIPTION
Reverts DJLink/list-of-game-engines-and-frameworks#6

beef is only a programming language, not a game tool itself f